### PR TITLE
Feature/docs rate limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ tqdm==4.67.1
 typing-inspection==0.4.1
 typing_extensions==4.14.1
 uvicorn==0.35.0
+slowapi==0.1.9

--- a/src/wanderwise/__init__.py
+++ b/src/wanderwise/__init__.py
@@ -1,0 +1,4 @@
+"""WanderWise package.
+
+Provides the FastAPI application and core domain logic for AI‑powered travel itinerary planning.
+"""

--- a/src/wanderwise/adapters/__init__.py
+++ b/src/wanderwise/adapters/__init__.py
@@ -1,0 +1,4 @@
+"""Adapters package.
+
+Contains gateway implementations that adapt external services (e.g., OpenAI) to the internal LLMPort interface.
+"""

--- a/src/wanderwise/application/__init__.py
+++ b/src/wanderwise/application/__init__.py
@@ -1,0 +1,4 @@
+"""Application package.
+
+Contains use‑case implementations and service classes that orchestrate business logic.
+"""

--- a/src/wanderwise/domain/__init__.py
+++ b/src/wanderwise/domain/__init__.py
@@ -1,0 +1,4 @@
+"""Domain package.
+
+Defines core business entities and value objects for the travel itinerary domain.
+"""

--- a/src/wanderwise/domain/models/__init__.py
+++ b/src/wanderwise/domain/models/__init__.py
@@ -1,0 +1,4 @@
+"""Domain models package.
+
+Contains Pydantic data models that represent the core entities such as Itinerary, Activity, and DailyPlan.
+"""

--- a/src/wanderwise/domain/ports/__init__.py
+++ b/src/wanderwise/domain/ports/__init__.py
@@ -1,0 +1,4 @@
+"""Domain ports package.
+
+Defines abstract interfaces (ports) that decouple the core domain from external services, such as the LLMPort.
+"""

--- a/src/wanderwise/infrastructure/__init__.py
+++ b/src/wanderwise/infrastructure/__init__.py
@@ -1,0 +1,4 @@
+"""Infrastructure package.
+
+Provides concrete implementations for cross‑cutting concerns such as logging configuration.
+"""

--- a/src/wanderwise/presentation/__init__.py
+++ b/src/wanderwise/presentation/__init__.py
@@ -1,0 +1,4 @@
+"""Presentation package.
+
+Contains FastAPI routers, dependency injection helpers, static assets, and Jinja2 templates for the web UI.
+"""

--- a/src/wanderwise/presentation/routers/__init__.py
+++ b/src/wanderwise/presentation/routers/__init__.py
@@ -1,0 +1,4 @@
+"""Routers package.
+
+Defines FastAPI APIRouter instances that expose the web endpoints for the application.
+"""

--- a/src/wanderwise/presentation/templates/__init__.py
+++ b/src/wanderwise/presentation/templates/__init__.py
@@ -1,0 +1,4 @@
+"""Templates package.
+
+Contains Jinja2 HTML templates used for rendering the web UI.
+"""


### PR DESCRIPTION
This pull request primarily adds descriptive docstrings to all package-level `__init__.py` files, clarifying the responsibilities and contents of each package. Additionally, it introduces global rate limiting to the FastAPI application using SlowAPI, and configures OpenAPI documentation endpoints. These changes improve both the maintainability of the codebase and the robustness of the API.

**Documentation Improvements:**

* Added module-level docstrings to all major package `__init__.py` files, providing clear descriptions for `wanderwise`, `adapters`, `application`, `domain`, `domain/models`, `domain/ports`, `infrastructure`, `presentation`, `presentation/routers`, and `presentation/templates` packages. [[1]](diffhunk://#diff-c8d3db5ff4537705c8faf1c05d0cf7eab4f56c57bc79a3e66e4b7b7bb55afd62R1-R4) [[2]](diffhunk://#diff-dab6c4223e9e04d9c5890fcfd172035f10381fd214dd52dc961be6dac8bf0136R1-R4) [[3]](diffhunk://#diff-5d12dab845dc32f28be6960d3cf7e6b1550eb77ae487dd89848aa4950c2f6c5aR1-R4) [[4]](diffhunk://#diff-d3b37b6a603ce20df0a7fd2819a27582717ded468ebac5b264dd33a15e557e74R1-R4) [[5]](diffhunk://#diff-d057241e9d9be11ca3a28f3069e35af840be0f43b3d5d3ebfa8b8da6eafc6cb8R1-R4) [[6]](diffhunk://#diff-1a5aa7fe626d08621b929f05ca69e37f164f51d56634a5d9f07e0da9f85bf24cR1-R4) [[7]](diffhunk://#diff-f8f518eb43baba08e952e8cabbc5fb256b703423e553b5f2ac709d2537919e33R1-R4) [[8]](diffhunk://#diff-99257d4ee29104ab7de855ce5107e401dce50ab6622d7b038c0fff0e1cd675cfR1-R4) [[9]](diffhunk://#diff-b7034041c9321b7a6a6abdea099adb129aa1b092465a0165844f40cdfb47f0b9R1-R4) [[10]](diffhunk://#diff-b7c7f05bd58ba1f7fdf916f157999a2b2ec60ed9432ce245935c0e54fcd1347eR1-R4)

**API and Middleware Enhancements:**

* Integrated SlowAPI for global rate limiting on all routes, including necessary imports, middleware registration, and exception handling in `main.py`. The default limit is set to 100 requests per minute per client. [[1]](diffhunk://#diff-eccbbaeb475f60497ac60c6e9ab954a1d932206a1559de30c39775af29c1b5f1R7-R10) [[2]](diffhunk://#diff-eccbbaeb475f60497ac60c6e9ab954a1d932206a1559de30c39775af29c1b5f1R32-R43) [[3]](diffhunk://#diff-eccbbaeb475f60497ac60c6e9ab954a1d932206a1559de30c39775af29c1b5f1R60-R64)
* Explicitly set OpenAPI schema and documentation URLs (`/openapi.json`, `/docs`, `/redoc`) in the FastAPI app configuration.